### PR TITLE
Mark stream end to detect file truncation

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -34,7 +34,7 @@
         },
         "UnwrapSubstr": {
             "ignoreSourceCodeByRegex": [
-                ".+ = substr\\(\\$this->buffer,( 0,)? self::(EN|DE)CRYPT_READ_BYTES\\);"
+                ".+ = substr\\(\\$this->buffer,( 0,)? \\$(read|write)ChunkSize\\);"
             ]
         }
     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -23,5 +23,8 @@
       <code>EncryptorStreamFilterTest</code>
       <code>EncryptorStreamFilterTest</code>
     </PropertyNotSetInConstructor>
+    <UnusedFunctionCall occurrences="1">
+      <code>stream_get_contents</code>
+    </UnusedFunctionCall>
   </file>
 </files>

--- a/test/CompressAndEncryptAdapterTest.php
+++ b/test/CompressAndEncryptAdapterTest.php
@@ -198,15 +198,22 @@ final class CompressAndEncryptAdapterTest extends FilesystemAdapterTestCase
     public function regression(): void
     {
         $key = 'RjWFkMrJS4Jd5TDdhYJNAWdfSEL5nptu4KQHgkeKGI0=';
-        $content = base64_decode('IZS+uLwIi3vfk+/txrq+7V7vQ0GGN9cwWetC8p/IRMstNUFfxB363Dt1jwxM7LbK3M4EX4earQ==', true);
-
+        $originalPlain = 'foobar';
         $adapter = new CompressAndEncryptAdapter(
             new LocalFilesystemAdapter($this->remoteMock),
             $key
         );
+
+        // To recreate assets, uncomment following lines
+        // $adapter->write('/file.txt', $originalPlain, new Config());
+        // var_dump(
+        //     base64_encode(file_get_contents($this->remoteMock.'/file.txt'.CompressAndEncryptAdapter::REMOTE_FILE_EXTENSION))
+        // ); exit;
+
+        $content = base64_decode('Zp1CKRNAdEebRInjHnuJwuG1gI2owWedBVboddwd+sW4AKv/3a112UjHnlpJntUUZgPBStuSFw==', true);
         file_put_contents($this->remoteMock.'/file.txt'.CompressAndEncryptAdapter::REMOTE_FILE_EXTENSION, $content);
 
-        static::assertSame('foobar', $adapter->read('/file.txt'));
+        static::assertSame($originalPlain, $adapter->read('/file.txt'));
     }
 
     /**

--- a/test/EncryptorStreamFilterTest.php
+++ b/test/EncryptorStreamFilterTest.php
@@ -135,9 +135,17 @@ final class EncryptorStreamFilterTest extends TestCase
     public function regression(): void
     {
         $key = base64_decode('Z+Ry4nDufKcJ19pU2pEMgGiac9GBWFjEV18Cpb9jxRM=', true);
-        $cipher = base64_decode('PMRzbW/xSj1WPnXp0DknCZvmM1Lv1XCYNbQH5wHozLpULVaGnoq7kVOuhg5Guew=', true);
-
+        $originalPlain = 'foobar';
         EncryptorStreamFilter::register();
+
+        // To recreate assets, uncomment following lines
+        // $cipherStream = $this->streamFromContents($content);
+        // EncryptorStreamFilter::appendEncryption($cipherStream, $key);
+        // $cipher = stream_get_contents($cipherStream);
+        // fclose($cipherStream);
+        // var_dump(base64_encode($cipher)); exit;
+
+        $cipher = base64_decode('UbQpWpd03RyW8a2YiVQSlkmfeEN76IgkN67yPRb7UoXcxUeL7LmUGizXL7zwbtc=', true);
 
         $plainStream = $this->streamFromContents($cipher);
         EncryptorStreamFilter::appendDecryption($plainStream, $key);
@@ -146,7 +154,7 @@ final class EncryptorStreamFilterTest extends TestCase
 
         fclose($plainStream);
 
-        static::assertSame('foobar', $plain);
+        static::assertSame($originalPlain, $plain);
     }
 
     /**


### PR DESCRIPTION
- Use sodium constant to determine auth tag length
- Add tag check to detect message truncation
- Recreate regression tests
